### PR TITLE
Update CS RelNotes 4.2.x to 4.3

### DIFF
--- a/source/rnotes.rst
+++ b/source/rnotes.rst
@@ -26,6 +26,114 @@ made while CloudStack was in the Apache Incubator.
 If you run into any issues during upgrades, please feel free to ask
 questions on users@cloudstack.apache.org or dev@cloudstack.apache.org.
 
+Validate 4.3 source code tarball
+--------------------------------
+
+#. 
+
+   Perform the following to verify the artifacts:
+
+   #. 
+
+      (optional) Install GPG keys if needed:
+
+      .. sourcecode:: bash
+   	  
+          $ sudo apt-get install gpg
+
+   #. 
+
+      Import the GPG keys stored in the source distribution's KEYS file
+
+      .. sourcecode:: bash
+
+          $ gpg --import KEYS
+
+      Alternatively, download the signing keys, the IDs found in the
+      KEYS file, individually by using a keyserver.
+
+      For example:
+
+      .. sourcecode:: bash
+
+          $ gpg --recv-keys CC56CEA8
+
+   #. 
+
+      Verify signatures and hash files:
+
+      .. sourcecode:: bash
+
+          $ gpg --verify apache-cloudstack-4.3-src.tar.bz2.asc
+          $ gpg --print-md MD5 apache-cloudstack-4.3-src.tar.bz2 | diff - apache-cloudstack-4.3-src.tar.bz2.md5
+          $ gpg --print-md SHA512 apache-cloudstack-4.3-src.tar.bz2 | diff - apache-cloudstack-4.3-src.tar.bz2.sha
+
+      Each of these commands should return no output. Any output from
+      them implies that there is a difference between the hash you
+      generated locally and the hash that has been pulled from the
+      server.
+
+   #. 
+
+      Get the commit hash from the VOTE email.
+
+      For example: ``4cd60f3d1683a3445c3248f48ae064fb573db2a1``. The
+      value changes between releases.
+
+   #. 
+
+      Create two new temporary directories:
+
+      .. sourcecode:: bash
+
+          $ mkdir /tmp/cloudstack/git
+          $ mkdir /tmp/cloudstack/tree
+
+   #. 
+
+      Check out the 4.3 branch:
+
+      .. sourcecode:: bash
+
+          $ git clone https://git-wip-us.apache.org/repos/asf/cloudstack.git /tmp/cloudstack/git
+          $ cd /tmp/cloudstack/git
+          $ git archive --format=tar --prefix=/tmp/cloudstack/tree/ <commit-hash> | tar Pxf -
+
+   #. 
+
+      Unpack the release artifact:
+
+      .. sourcecode:: bash
+
+          $ cd /tmp/cloudstack
+          $ tar xvfj apache-cloudstack-4.3-src.tar.bz2
+
+   #. 
+
+      Compare the contents of the release artifact with the contents
+      pulled from the repo:
+
+      .. sourcecode:: bash
+
+          $ diff -r /tmp/cloudstack/apache-cloudstack-4.3-src /tmp/cloudstack/tree
+
+      Ensure that content is the same.
+
+   #. 
+
+      Verify the Code License Headers:
+
+      .. sourcecode:: bash
+
+          $ cd /tmp/cloudstack/apache-cloudstack-4.3-src
+          $ mvn --projects='org.apache.cloudstack:cloudstack' org.apache.rat:apache-rat-plugin:0.8:check
+
+      The build fails if any non-compliant files are present that are
+      not specifically excluded from the ASF license header requirement.
+      You can optionally review the target/rat.txt file after the run
+      completes. Passing the build implies that RAT certifies that the
+      files are compliant and this test is passed.
+
 Upgrade from 4.2.x to 4.3
 -------------------------
 
@@ -157,8 +265,8 @@ working on a production system.
    the 4.3 source, or check the Apache CloudStack downloads page at
    `http://cloudstack.apache.org/downloads.html <http://cloudstack.apache.org/downloads.html>`__
    for package repositories supplied by community members. You will need
-   them for step `9 <#upgrade-deb-packages-4.3>`__ or step
-   `12 <#upgrade-rpm-packages-4.3>`__.
+   them for step `8 <#upgrade-deb-packages-4.3>`__ or step
+   `11 <#upgrade-rpm-packages-4.3>`__.
 
    Instructions for creating packages from the CloudStack source are in
    the `Installation
@@ -195,111 +303,6 @@ working on a production system.
 
 #. 
 
-   Perform the following to verify the artifacts:
-
-   #. 
-
-      (optional) Install GPG keys if needed:
-
-      .. sourcecode:: bash
-   	  
-          $ sudo apt-get install gpg
-
-   #. 
-
-      Import the GPG keys stored in the source distribution's KEYS file
-
-      .. sourcecode:: bash
-
-          $ gpg --import KEYS
-
-      Alternatively, download the signing keys, the IDs found in the
-      KEYS file, individually by using a keyserver.
-
-      For example:
-
-      .. sourcecode:: bash
-
-          $ gpg --recv-keys CC56CEA8
-
-   #. 
-
-      Verify signatures and hash files:
-
-      .. sourcecode:: bash
-
-          $ gpg --verify apache-cloudstack-4.3-src.tar.bz2.asc
-          $ gpg --print-md MD5 apache-cloudstack-4.3-src.tar.bz2 | diff - apache-cloudstack-4.3-src.tar.bz2.md5
-          $ gpg --print-md SHA512 apache-cloudstack-4.3-src.tar.bz2 | diff - apache-cloudstack-4.3-src.tar.bz2.sha
-
-      Each of these commands should return no output. Any output from
-      them implies that there is a difference between the hash you
-      generated locally and the hash that has been pulled from the
-      server.
-
-   #. 
-
-      Get the commit hash from the VOTE email.
-
-      For example: ``4cd60f3d1683a3445c3248f48ae064fb573db2a1``. The
-      value changes between releases.
-
-   #. 
-
-      Create two new temporary directories:
-
-      .. sourcecode:: bash
-
-          $ mkdir /tmp/cloudstack/git
-          $ mkdir /tmp/cloudstack/tree
-
-   #. 
-
-      Check out the 4.3 branch:
-
-      .. sourcecode:: bash
-
-          $ git clone https://git-wip-us.apache.org/repos/asf/cloudstack.git /tmp/cloudstack/git
-          $ cd /tmp/cloudstack/git
-          $ git archive --format=tar --prefix=/tmp/cloudstack/tree/ <commit-hash> | tar Pxf -
-
-   #. 
-
-      Unpack the release artifact:
-
-      .. sourcecode:: bash
-
-          $ cd /tmp/cloudstack
-          $ tar xvfj apache-cloudstack-4.3-src.tar.bz2
-
-   #. 
-
-      Compare the contents of the release artifact with the contents
-      pulled from the repo:
-
-      .. sourcecode:: bash
-
-          $ diff -r /tmp/cloudstack/apache-cloudstack-4.3-src /tmp/cloudstack/tree
-
-      Ensure that content is the same.
-
-   #. 
-
-      Verify the Code License Headers:
-
-      .. sourcecode:: bash
-
-          $ cd /tmp/cloudstack/apache-cloudstack-4.3-src
-          $ mvn --projects='org.apache.cloudstack:cloudstack' org.apache.rat:apache-rat-plugin:0.8:check
-
-      The build fails if any non-compliant files are present that are
-      not specifically excluded from the ASF license header requirement.
-      You can optionally review the target/rat.txt file after the run
-      completes. Passing the build implies that RAT certifies that the
-      files are compliant and this test is passed.
-
-#. 
-
    (KVM Only) If primary storage of type local storage is in use, the
    path for this storage needs to be verified to ensure it passes new
    validation. Check local storage by querying the cloud.storage\_pool
@@ -319,7 +322,7 @@ working on a production system.
 #. 
 
    If you are using Ubuntu, follow this procedure to upgrade your
-   packages. If not, skip to step `12 <#upgrade-rpm-packages-4.3>`__.
+   packages. If not, skip to step `11 <#upgrade-rpm-packages-4.3>`__.
 
    .. note:: **Community Packages:** This section assumes you're using the community supplied packages for CloudStack. If you've created your own packages and APT repository, substitute your own URL for the ones used in these examples.
 


### PR DESCRIPTION
- Break out validation step as it applies to all upgrades and installations
- Update visual format of commands
- Update instructions for 4.2.x upgrade
- Reordered and clarified agent upgrade steps
