### PR TITLE
rnotes.rst: fix release refences in upgrade notes

### DIFF
--- a/source/rnotes.rst
+++ b/source/rnotes.rst
@@ -783,7 +783,7 @@ working on a production system.
 #. 
 
    Create RPM or Debian packages (as appropriate) and a repository from
-   the 4.2.1 source, or check the Apache CloudStack downloads page at
+   the 4.3 source, or check the Apache CloudStack downloads page at
    `http://cloudstack.apache.org/downloads.html <http://cloudstack.apache.org/downloads.html>`__
    for package repositories supplied by community members. You will need
    them for step `8 <#upgrade-deb-packages-41to42>`__ or step
@@ -863,7 +863,7 @@ working on a production system.
 
       .. sourcecode:: bash
 
-          deb http://cloudstack.apt-get.eu/ubuntu precise 4.0
+          deb http://cloudstack.apt-get.eu/ubuntu precise 4.1
 
       We'll change it to point to the new package repository:
 
@@ -1082,12 +1082,12 @@ working on a production system.
 
           [apache-cloudstack]
           name=Apache CloudStack
-          baseurl=http://cloudstack.apt-get.eu/rhel/4.0/
+          baseurl=http://cloudstack.apt-get.eu/rhel/4.1/
           enabled=1
           gpgcheck=0
 
       If you are using the community provided package repository, change
-      the base url to http://cloudstack.apt-get.eu/rhel/4.2/
+      the base url to http://cloudstack.apt-get.eu/rhel/4.3/
 
       If you're using your own package repository, change this line to
       read as appropriate for your 4.3 repository.
@@ -1209,7 +1209,7 @@ working on a production system.
    Enterprise Linux or CentOS), or APT and Debian packages (for Ubuntu).
 
    Create RPM or Debian packages (as appropriate) and a repository from
-   the 4.1.0 source, or check the Apache CloudStack downloads page at
+   the 4.3 source, or check the Apache CloudStack downloads page at
    `http://cloudstack.apache.org/downloads.html <http://cloudstack.apache.org/downloads.html>`__
    for package repositories supplied by community members. You will need
    them for step `9 <#upgrade-deb-packages-40to41>`__ or step
@@ -1429,7 +1429,7 @@ working on a production system.
           deb http://cloudstack.apt-get.eu/ubuntu precise 4.3
 
       If you're using your own package repository, change this line to
-      read as appropriate for your 4.1.0 repository.
+      read as appropriate for your 4.3 repository.
 
    #. 
 
@@ -1541,7 +1541,7 @@ working on a production system.
                                           gpgcheck=0
 
       If you are using the community provided package repository, change
-      the baseurl to http://cloudstack.apt-get.eu/rhel/4.1/
+      the baseurl to http://cloudstack.apt-get.eu/rhel/4.3/
 
       If you're using your own package repository, change this line to
       read as appropriate for your 4.3 repository.
@@ -1784,15 +1784,15 @@ with a note.
                       gpgcheck=0
                       [apache CloudStack]
                       name= Apache CloudStack
-                      baseurl= http://cloudstack.apt-get.eu/rhel/4.0/
+                      baseurl= http://cloudstack.apt-get.eu/rhel/4.3/
                       enabled=1
                       gpgcheck=0
 
       If you are using the community provided package repository, change
-      the baseurl to http:// cloudstack.apt-get.eu/rhel/4.2/
+      the baseurl to http:// cloudstack.apt-get.eu/rhel/4.3/
 
       If you are using your own package repository, change this line to
-      read as appropriate for your 4.2 repository.
+      read as appropriate for your 4.3 repository.
 
    #. 
 
@@ -1978,15 +1978,15 @@ with a note.
 
           [apache-cloudstack]
           name=Apache CloudStack
-          baseurl=http://cloudstack.apt-get.eu/rhel/4.0/
+          baseurl=http://cloudstack.apt-get.eu/rhel/4.3/
           enabled=1
           gpgcheck=0
 
       If you are using the community provided package repository, change
-      the baseurl to http://cloudstack.apt-get.eu/rhel/4.2/
+      the baseurl to http://cloudstack.apt-get.eu/rhel/4.3/
 
       If you're using your own package repository, change this line to
-      read as appropriate for your 4.2 repository.
+      read as appropriate for your 4.3 repository.
 
    #. 
 


### PR DESCRIPTION
Fixed some Version numbers in upgrade notes based from Seb message in the mailinglist thread: _Documentation question/verification (upgrade from 4.0 to 4.2.1)_
