### PR TITLE
Fixed assorted typos.

### DIFF
--- a/source/about.rst
+++ b/source/about.rst
@@ -23,7 +23,7 @@ CloudStack |version| includes the following new features and improvements.
    :local:
    :backlinks: top
 
-Java version upgraded to java 1.7
+Java version upgraded to Java 1.7
 ---------------------------------
 
 Apache CloudStack |version| is now using Java 1.7 for the management-server, cloudstack-usage, kvm agent and in system-VMs.

--- a/source/upgrade/upgrade-4.3.rst
+++ b/source/upgrade/upgrade-4.3.rst
@@ -194,7 +194,7 @@ packages. If not, skip to hypervisors section, then :ref:`upg-sysvm43`.
 
 .. _rpm-repo43:
 
-CloustStack RPM repository
+CloudStack RPM repository
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
    The first order of business will be to change the yum repository
@@ -238,7 +238,7 @@ CloustStack RPM repository
       $ sudo yum upgrade cloudstack-usage
 
 
-hypervisor: XenServer
+Hypervisor: XenServer
 ---------------------
 
    **(XenServer only)** Copy vhd-utils file on CloudStack management servers.
@@ -251,7 +251,7 @@ hypervisor: XenServer
       http://download.cloud.com.s3.amazonaws.com/tools/vhd-util
 
 
-hypervisor: VMware
+Hypervisor: VMware
 ------------------
 
    .. warning::
@@ -324,7 +324,7 @@ hypervisor: VMware
 
 .. _kvm43:
 
-hypervisor: KVM
+Hypervisor: KVM
 ---------------
 
 KVM on Ubuntu

--- a/source/upgrade/upgrade_notes.rst
+++ b/source/upgrade/upgrade_notes.rst
@@ -74,7 +74,7 @@ ldap.username.attribute uid            sAMAccountName
 SystemVM 32bit deprecated
 -------------------------
 
-32bit version of systemvm templates are in the process of behing deprecated. Upgrade instructions from this Release Notes use 64bit templates. 32bit systemvm-templates are available for this version on `http://cloudstack.apt-get.eu/systemvm/4.4/ <http://cloudstack.apt-get.eu/systemvm/4.4/>`_. Follow the dev mailing list for further updates.
+32bit versions of systemvm templates are in the process of behing deprecated. Upgrade instructions from this Release Notes use 64bit templates. 32bit systemvm-templates are available for this version on `http://cloudstack.apt-get.eu/systemvm/4.4/ <http://cloudstack.apt-get.eu/systemvm/4.4/>`_. Follow the dev mailing list for further updates.
 
 
 .. not confirmed 


### PR DESCRIPTION
Corrected a few typos I found while going through the documentation.

The text "hypervisor" changed case in order to match previous release notes, and to match the case of other items on the page.
