### PR TITLE
Fix CLOUDSTACK-8540: Update template with Hyper-V and VHD

### DIFF
--- a/source/upgrade/_sysvm_templates.rst
+++ b/source/upgrade/_sysvm_templates.rst
@@ -123,9 +123,9 @@ Update System-VM templates
    |            |                                                            |
    |            | Zone: Choose the zone where this hypervisor is used        |
    |            |                                                            |
-   |            | Hypervisor: VMware                                         |
+   |            | Hypervisor: Hyper-V                                        |
    |            |                                                            |
-   |            | Format: OVA                                                |
+   |            | Format: VHD                                                |
    |            |                                                            |
    |            | OS Type: Debian GNU/Linux 7.0 (64-bit) (or the             |
    |            | highest Debian release number available in the             |


### PR DESCRIPTION
Fix CLOUDSTACK-8540:

- Updated the upgrade template documentation with the right hypervisor (Hyper-V) and the Hard disk type to VHD.