### PR TITLE
fix pre 4.5 upgrade instruction

### DIFF
--- a/source/about.rst
+++ b/source/about.rst
@@ -89,6 +89,21 @@ Link                   https://hub.docker.com/u/cloudstack/
 ====================== ============================================================================
 
 
+Deprecation of awsapi
+---------------------
+
+The module awsapi as been removed from the source code and replaced by ec2stack
+(https://github.com/apache/cloudstack-ec2stack). Removal of awsapi change the
+upgrade process to 4.6 from previous release as the RPM cloudstack-awsapi must
+be removed. This deprecation removed close to 1 million lines of code from the
+source base.
+
+====================== ============================================================================
+Supported hypervisors: N/A
+Link                   `CLOUDSTACK-8433`_
+====================== ============================================================================
+
+
 Improvements
 ------------
 
@@ -204,3 +219,4 @@ Jira ID             Description
 .. _CLOUDSTACK-8989 : https://issues.apache.org/jira/browse/CLOUDSTACK-8989
 .. _CLOUDSTACK-8992 : https://issues.apache.org/jira/browse/CLOUDSTACK-8992
 .. _CLOUDSTACK-9044 : https://issues.apache.org/jira/browse/CLOUDSTACK-9044
+.. _CLOUDSTACK-8433 : https://issues.apache.org/jira/browse/CLOUDSTACK-8433

--- a/source/about.rst
+++ b/source/about.rst
@@ -92,7 +92,7 @@ Link                   https://hub.docker.com/u/cloudstack/
 Deprecation of awsapi
 ---------------------
 
-The module awsapi as been removed from the source code and replaced by ec2stack
+The module awsapi has been removed from the source code and replaced by ec2stack
 (https://github.com/apache/cloudstack-ec2stack). Removal of awsapi change the
 upgrade process to 4.6 from previous release as the RPM cloudstack-awsapi must
 be removed. This deprecation removed close to 1 million lines of code from the

--- a/source/global.rst
+++ b/source/global.rst
@@ -27,7 +27,7 @@
 .. |sysvm64-url-hyperv| replace:: http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-hyperv.vhd.zip
 .. |sysvm64-url-ovm|    replace:: http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-ovm.raw.bz2
 
-.. Version specific: 4.3 systemvm template URL
+.. Version specific: 4.5 systemvm template URL
 .. |acs45-sysvm64-url-xen|    replace:: http://cloudstack.apt-get.eu/systemvm/4.5/systemvm64template-4.5-xen.vhd.bz2
 .. |acs45-sysvm64-url-kvm|    replace:: http://cloudstack.apt-get.eu/systemvm/4.5/systemvm64template-4.5-kvm.qcow2.bz2
 .. |acs45-sysvm64-url-vmware| replace:: http://cloudstack.apt-get.eu/systemvm/4.5/systemvm64template-4.5-vmware.ova

--- a/source/global.rst
+++ b/source/global.rst
@@ -28,7 +28,7 @@
 .. |sysvm64-url-ovm|    replace:: http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-ovm.raw.bz2
 
 .. Version specific: 4.3 systemvm template URL
-.. |acs43-sysvm64-url-xen|    replace:: http://packages.shapeblue.com/systemvmtemplate/4.3/systemvm64template-4.3-xen.vhd.bz2
-.. |acs43-sysvm64-url-kvm|    replace:: http://packages.shapeblue.com/systemvmtemplate/4.3/systemvm64template-4.3-kvm.qcow2.bz2
-.. |acs43-sysvm64-url-vmware| replace:: http://packages.shapeblue.com/systemvmtemplate/4.3/systemvm64template-4.3-vmware.ova
-.. |acs43-sysvm64-url-hyperv| replace:: http://download.cloud.com/templates/4.3/systemvm64template-2014-06-23-master-hyperv.vhd.bz2
+.. |acs45-sysvm64-url-xen|    replace:: http://cloudstack.apt-get.eu/systemvm/4.5/systemvm64template-4.5-xen.vhd.bz2
+.. |acs45-sysvm64-url-kvm|    replace:: http://cloudstack.apt-get.eu/systemvm/4.5/systemvm64template-4.5-kvm.qcow2.bz2
+.. |acs45-sysvm64-url-vmware| replace:: http://cloudstack.apt-get.eu/systemvm/4.5/systemvm64template-4.5-vmware.ova
+.. |acs45-sysvm64-url-hyperv| replace:: http://cloudstack.apt-get.eu/systemvm/4.5/systemvm64template-4.5-hyperv.vhd.zip

--- a/source/upgrade/_sysvm_templates_pre45.rst
+++ b/source/upgrade/_sysvm_templates_pre45.rst
@@ -18,8 +18,9 @@
 Update System-VM templates
 --------------------------
 
-.. note::
-   Upgrading pre-4.3 to 4.4.1 require 2 systemvm templates downloaded: the 4.3 and 4.4.
+.. warning::
+   Upgrading from 4.4 or older to 4.6.0 require 2 systemvm templates to be
+   downloaded, for 4.5 and 4.6.
 
 #. While running the existing |version_to_upgrade| system, log in to the UI as 
    root administrator.
@@ -28,7 +29,7 @@ Update System-VM templates
 
 #. In Select view, click Templates.
 
-#. Register 4.3 systemvm template:
+#. Register 4.5 systemvm template:
    
    #. Click Register template.
 
@@ -36,15 +37,17 @@ Update System-VM templates
 
    #. In the Register template dialog box, specify the following values
       (do not change these):
+
+      .. cssclass:: table-striped table-bordered table-hover
    
       +------------+------------------------------------------------------------+
       | Hypervisor | Description                                                |
       +============+============================================================+
-      | XenServer  | Name: systemvm-xenserver-4.3                               |
+      | XenServer  | Name: systemvm-xenserver-4.5                               |
       |            |                                                            |
-      |            | Description: systemvm-xenserver-4.3                        |
+      |            | Description: systemvm-xenserver-4.5                        |
       |            |                                                            |
-      |            | URL: |acs43-sysvm64-url-xen|                               |
+      |            | URL: |acs45-sysvm64-url-xen|                               |
       |            |                                                            |
       |            | Zone: Choose the zone where this hypervisor is used        |
       |            |                                                            |
@@ -66,11 +69,11 @@ Update System-VM templates
       |            |                                                            |
       |            | Routing: no                                                |
       +------------+------------------------------------------------------------+
-      | KVM        | Name: systemvm-kvm-4.3                                     |
+      | KVM        | Name: systemvm-kvm-4.5                                     |
       |            |                                                            |
-      |            | Description: systemvm-kvm-4.3                              |
+      |            | Description: systemvm-kvm-4.5                              |
       |            |                                                            |
-      |            | URL: |acs43-sysvm64-url-kvm|                               |  
+      |            | URL: |acs45-sysvm64-url-kvm|                               |  
       |            |                                                            |
       |            | Zone: Choose the zone where this hypervisor is used        |
       |            |                                                            |
@@ -92,11 +95,11 @@ Update System-VM templates
       |            |                                                            |
       |            | Routing: no                                                |
       +------------+------------------------------------------------------------+
-      | VMware     | Name: systemvm-vmware-4.3                                  |
+      | VMware     | Name: systemvm-vmware-4.5                                  |
       |            |                                                            |
-      |            | Description: systemvm-vmware-4.3                           |
+      |            | Description: systemvm-vmware-4.5                           |
       |            |                                                            |
-      |            | URL: |acs43-sysvm64-url-vmware|                            |
+      |            | URL: |acs45-sysvm64-url-vmware|                            |
       |            |                                                            |
       |            | Zone: Choose the zone where this hypervisor is used        |
       |            |                                                            |
@@ -127,6 +130,8 @@ Update System-VM templates
 
    #. In the Register template dialog box, specify the following values
       (do not change these):
+
+      .. cssclass:: table-striped table-bordered table-hover
       
       +------------+------------------------------------------------------------+
       | Hypervisor | Description                                                |

--- a/source/upgrade/upgrade-4.2.rst
+++ b/source/upgrade/upgrade-4.2.rst
@@ -54,7 +54,7 @@ them for :ref:`ubuntu42` or :ref:`rhel42` and :ref:`kvm42` hosts upgrade.
 Instructions for creating packages from the CloudStack source are in the 
 `CloudStack Installation Guide`_.
 
-.. include:: _sysvm_templates.rst
+.. include:: _sysvm_templates_pre45.rst
 
 
 Database Preparation

--- a/source/upgrade/upgrade-4.2.rst
+++ b/source/upgrade/upgrade-4.2.rst
@@ -221,6 +221,12 @@ Setup the GPG public key if you wish to enable ``gpgcheck=1``:
 If you're using your own package repository, change this line to
 read as appropriate for your |version| repository.
 
+#. Remove the deprecated dependency for awsapi.
+
+   .. sourcecode:: bash
+
+      $ sudo rpm -e --nodeps cloudstack-awsapi
+
 #. Now that you have the repository configured, it's time to upgrade the 
    ``cloudstack-management``.
 

--- a/source/upgrade/upgrade-4.3.rst
+++ b/source/upgrade/upgrade-4.3.rst
@@ -58,7 +58,7 @@ them for :ref:`ubuntu43` or :ref:`rhel43` and :ref:`kvm43` hosts upgrade.
 Instructions for creating packages from the CloudStack source are in the 
 `CloudStack Installation Guide`_.
 
-.. include:: _sysvm_templates.rst
+.. include:: _sysvm_templates_pre45.rst
 
 
 Database Preparation

--- a/source/upgrade/upgrade-4.3.rst
+++ b/source/upgrade/upgrade-4.3.rst
@@ -224,6 +224,11 @@ Setup the GPG public key if you wish to enable ``gpgcheck=1``:
 If you're using your own package repository, change this line to
 read as appropriate for your |version| repository.
 
+#. Remove the deprecated dependency for awsapi.
+
+   .. sourcecode:: bash
+
+      $ sudo rpm -e --nodeps cloudstack-awsapi
 
 #. Now that you have the repository configured, it's time to upgrade the 
    ``cloudstack-management``.

--- a/source/upgrade/upgrade-4.4.rst
+++ b/source/upgrade/upgrade-4.4.rst
@@ -58,7 +58,7 @@ them for :ref:`ubuntu44` or :ref:`rhel44` and :ref:`kvm44` hosts upgrade.
 Instructions for creating packages from the CloudStack source are in the 
 `CloudStack Installation Guide`_.
 
-.. include:: _sysvm_templates.rst
+.. include:: _sysvm_templates_pre45.rst
 
 
 Database Preparation

--- a/source/upgrade/upgrade-4.4.rst
+++ b/source/upgrade/upgrade-4.4.rst
@@ -226,6 +226,11 @@ Setup the GPG public key if you wish to enable ``gpgcheck=1``:
 If you're using your own package repository, change this line to
 read as appropriate for your |version| repository.
 
+#. Remove the deprecated dependency for awsapi.
+
+   .. sourcecode:: bash
+
+      $ sudo rpm -e --nodeps cloudstack-awsapi
 
 #. Now that you have the repository configured, it's time to upgrade the 
     ``cloudstack-management``.

--- a/source/upgrade/upgrade-4.5.rst
+++ b/source/upgrade/upgrade-4.5.rst
@@ -227,6 +227,11 @@ Setup the GPG public key if you wish to enable ``gpgcheck=1``:
 If you're using your own package repository, change this line to
 read as appropriate for your |version| repository.
 
+#. Remove the deprecated dependency for awsapi.
+
+   .. sourcecode:: bash
+
+      $ sudo rpm -e --nodeps cloudstack-awsapi
 
 #. Now that you have the repository configured, it's time to upgrade the 
    ``cloudstack-management``.


### PR DESCRIPTION
This go into master and 4.6 branch,  tag 4.6.0 must be redo to include following changes.

I'm suspecting more changes in the RN as we removed the package cloudstack-awsapi from the main repo which was required pre 4.5.
